### PR TITLE
Add a check in the Init function to stop the app gracefully if port bind fails

### DIFF
--- a/fsw/src/sntp.c
+++ b/fsw/src/sntp.c
@@ -66,7 +66,7 @@ int initUDPSocket(uint32_t port) {
     struct sockaddr_in serverAddr;
     memset(&serverAddr, 0, sizeof(serverAddr));
     serverAddr.sin_family = AF_INET;
-    serverAddr.sin_port = htons(SNTP_PORT);
+    serverAddr.sin_port = htons(port);
     serverAddr.sin_addr.s_addr = htonl(INADDR_ANY);
 
     if (bind(sockfd, (struct sockaddr*)&serverAddr, sizeof(serverAddr)) < 0) {
@@ -277,6 +277,11 @@ int32 SNTP_Init(void)
     }
 
     SNTP_Data.sockfd = initUDPSocket(SNTP_PORT);
+    if (SNTP_Data.sockfd < 0)
+    {
+        CFE_ES_WriteToSysLog("SNTP App: Error initializing UDP socket\n");
+        return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;        
+    }
     
     CFE_EVS_SendEvent(SNTP_STARTUP_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "cFE SNTP Server %s Initialized at port %d, running as stratum %d and serving "


### PR DESCRIPTION
Fixes Issue #1 

**To test:**
You can build cFS locally in your machine (use the branch feature/sntp, which adds this repo to the list of apps)  and try running:

```
./core-cpu1
```
In my machine, this produced a constant output of lines saying "-1: -8 Error in binding" (or something like that). This is because the port 123 couldn't be accessed unless I was root.  With this PR, you'll now see a message like this:
```
Error binding to server port: Permission denied
1980-012-14:03:20.55801 SNTP App: Error initializing UDP socket
SNTP Init Failed!
```
And a bit below you'll see a "SNTP App Completed" message showing that the app stopped.  No further spamming line will appear.

Note that if you run the core-cpu1 command with sudo, no error will appear. This fix is mostly for users that for some reason cannot use sudo or don't have access to their 123 port.